### PR TITLE
[New paper] Add a whitepaper on Neural Network Quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Papers proceeded by “See also” indicate either additional historical context
 
 ##### Quantization (Qualcomm)
 
-- **A White Paper on Neural Network Quantization (2021)**, Nagel et al., [@arXiv](https://arxiv.org/pdf/2106.08295.pdf) 🔬.
+- **A White Paper on Neural Network Quantization (2021)**, Nagel et al., [@arXiv](https://arxiv.org/abs/2106.08295) 🔬.
 
 #### Natural Language Processing
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Papers proceeded by “See also” indicate either additional historical context
 
 - **Building Watson: An Overview of the DeepQA Project (2010)**, Ferrucci et al., [@AAAI](https://www.aaai.org/ojs/index.php/aimagazine/article/view/2303).
 
+##### Quantization (Qualcomm)
+
+- **A White Paper on Neural Network Quantization (2021)**, Nagel et al., [@arXiv](https://arxiv.org/pdf/2106.08295.pdf) 🔬.
+
 #### Natural Language Processing
 
 ##### Latent Dirichlet Allocation


### PR DESCRIPTION
name: A White Paper on Neural Network Quantization
about: Quantization - from absolute basics to advanced concepts
labels: quantization, miscellaneous

**Topic:** *quantization*

**Paper title:** *A White Paper on Neural Network Quantization*

**Year:** *2021*

**Author(s):** *Nagel et al.*

**Canonical link:** *https://arxiv.org/abs/2106.08295*

**Notes:** It's a fantastic paper for geting into neural network quantization. It covers everything from absolute basics (including quantization justification explained in terms of hardware) up to advanced quantization techniques. I found it exceptionally useful and clear.